### PR TITLE
lexer: change to util from aux

### DIFF
--- a/elm_lexer.moon
+++ b/elm_lexer.moon
@@ -1,5 +1,5 @@
 
-howl.aux.lpeg_lexer ->
+howl.util.lpeg_lexer ->
   c = capture
 
   keyword = c 'keyword', word({


### PR DESCRIPTION
A small change to conform with the deprecation state of **aux** in
master.
